### PR TITLE
Add option for disabling fan out

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,13 +126,18 @@ class Subscriber extends events.EventEmitter {
       function removeListeners() {
         subscription.removeListener('message', onMessage);
         subscription.removeListener('error', onError);
-        process.removeListener('SIGTERM', deleteSubscription);
-        process.removeListener('SIGINT', deleteSubscription);
+
+        if (!this.disableFanOut) {
+          process.removeListener('SIGTERM', deleteSubscription);
+          process.removeListener('SIGINT', deleteSubscription);
+        }
       }
 
       // Handle termination, delete the subscription (require graceful shutdowm)
-      process.on('SIGTERM', deleteSubscription);
-      process.on('SIGINT', deleteSubscription);
+      if (!this.disableFanOut) {
+        process.on('SIGTERM', deleteSubscription);
+        process.on('SIGINT', deleteSubscription);
+      }
       
       // Bind the subscription
       subscription.on('message', onMessage);

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,6 @@ class Subscriber extends events.EventEmitter {
     }
 
     topic.subscribe(subscriptionName, (err, subscription) => {
-
       if (err) {
         console.error(`Failed to create subscription ${err}`);
         return;
@@ -90,14 +89,16 @@ class Subscriber extends events.EventEmitter {
 
       console.log(`Subscription ${subscription.name} created.`);
       
-      function deleteSubscription() {
+      const deleteSubscription = () => {
         removeListeners();
-        console.log('Subscriber: Signal received, deleting subscription');
-        subscription.delete().then(() => {
-          console.log('Subscriber: subscription deleted...');
-        }, (err) => {
-          console.error(`Subscriber: Error deleting subscription`, err);
-        });
+        if (!this.disableFanOut) {
+          console.log('Subscriber: Signal received, deleting subscription');
+          subscription.delete().then(() => {
+            console.log('Subscriber: subscription deleted...');
+          }, (err) => {
+            console.error(`Subscriber: Error deleting subscription`, err);
+          });
+        }
       }
       
       function messageHandler(message) {
@@ -127,17 +128,13 @@ class Subscriber extends events.EventEmitter {
         subscription.removeListener('message', onMessage);
         subscription.removeListener('error', onError);
 
-        if (!this.disableFanOut) {
-          process.removeListener('SIGTERM', deleteSubscription);
-          process.removeListener('SIGINT', deleteSubscription);
-        }
+        process.removeListener('SIGTERM', deleteSubscription);
+        process.removeListener('SIGINT', deleteSubscription);
       }
 
       // Handle termination, delete the subscription (require graceful shutdowm)
-      if (!this.disableFanOut) {
-        process.on('SIGTERM', deleteSubscription);
-        process.on('SIGINT', deleteSubscription);
-      }
+      process.on('SIGTERM', deleteSubscription);
+      process.on('SIGINT', deleteSubscription);
       
       // Bind the subscription
       subscription.on('message', onMessage);

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,8 +39,9 @@ class Publisher {
 
 class Subscriber extends events.EventEmitter {
 
-  constructor() {
+  constructor(options) {
     super();
+    this.disableFanOut = options.disableFanOut || false;
   }
 
   subscribe(channel) {
@@ -72,9 +73,13 @@ class Subscriber extends events.EventEmitter {
   }
 
   _createSubscription(topic, channel) {
-
-    const subscriptionUUID = uuid.v1();
-    var subscriptionName = `${namePrefix}-${channel}-${subscriptionUUID}`;
+    let subscriptionName;
+    if (!this.disableFanOut) {
+      const subscriptionUUID = uuid.v1();
+      subscriptionName = `${namePrefix}-${channel}-${subscriptionUUID}`;
+    } else {
+      subscriptionName = `${namePrefix}-${channel}`;
+    }
 
     topic.subscribe(subscriptionName, (err, subscription) => {
 
@@ -140,8 +145,8 @@ function createPublisher() {
   return new Publisher(emitter);
 }
 
-function createSubscriber() {
-  return new Subscriber();
+function createSubscriber(options) {
+  return new Subscriber(options);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server-gcloud-pubsub",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "google cloud pub/sub adapter for parse-server",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## Overview
- Add `disableFanOut` option to subscriber options.

This is useful for sending messages exactly once.

To use with push notifications on `parse-server`:
```javascript
// Parse config
{
 //...
 push: {
  // ...
   queueOptions: {
    messageQueueAdapter: 'parse-server-gcloud-pubsub',
    disableFanOut: true,
    disablePushWorker: false,
    channel: 'my-channel',
   }
 }
}
```